### PR TITLE
Fix undefined parameter handling across all Zulip API calls

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -159,10 +159,11 @@ export const GetUserByEmailSchema = z.object({
 });
 
 export const UpdateStatusSchema = z.object({
-  status_text: z.string().optional().describe("Status message text (e.g., 'In a meeting', 'Working from home')"),
-  away: z.boolean().optional().describe("Set away status (true = away, false = active)"),
-  emoji_name: z.string().optional().describe("Emoji name for status (e.g., 'coffee', 'airplane')"),
-  emoji_code: z.string().optional().describe("Unicode code for status emoji")
+  status_text: z.string().max(60).optional().describe("Status message text (max 60 chars, empty string clears status)"),
+  away: z.boolean().optional().describe("Set away status (deprecated in Zulip 6.0, will be removed)"),
+  emoji_name: z.string().optional().describe("Emoji name: for unicode use short name (e.g., 'coffee', 'airplane'), for realm_emoji use custom name, for zulip_extra use special names like 'zulip'"),
+  emoji_code: z.string().optional().describe("Emoji identifier: for unicode_emoji use codepoint (e.g., '2615' for coffee), for realm_emoji use custom emoji ID, for zulip_extra use emoji ID"),
+  reaction_type: z.enum(["unicode_emoji", "realm_emoji", "zulip_extra_emoji"]).optional().describe("Emoji type: 'unicode_emoji' for standard emojis (default), 'realm_emoji' for organization custom emojis, 'zulip_extra_emoji' for special Zulip emojis")
 });
 
 export const CreateDraftSchema = z.object({

--- a/src/zulip/client.ts
+++ b/src/zulip/client.ts
@@ -140,11 +140,12 @@ export class ZulipClient {
       return { messages: [response.data.message] };
     }
 
-    const queryParams: any = {
-      anchor: params.anchor || 'newest',
-      num_before: params.num_before || 20,
-      num_after: params.num_after || 0
-    };
+    const queryParams: any = {};
+    
+    // Only set parameters that are provided, with appropriate defaults
+    queryParams.anchor = params.anchor !== undefined ? params.anchor : 'newest';
+    queryParams.num_before = params.num_before !== undefined ? params.num_before : 20;
+    queryParams.num_after = params.num_after !== undefined ? params.num_after : 0;
 
     if (params.narrow) {
       queryParams.narrow = JSON.stringify(params.narrow);
@@ -158,7 +159,11 @@ export class ZulipClient {
     content?: string;
     topic?: string;
   }): Promise<void> {
-    await this.client.patch(`/messages/${messageId}`, params);
+    // Filter out undefined values
+    const filteredParams = Object.fromEntries(
+      Object.entries(params).filter(([_, value]) => value !== undefined)
+    );
+    await this.client.patch(`/messages/${messageId}`, filteredParams);
   }
 
   async deleteMessage(messageId: number): Promise<void> {
@@ -170,11 +175,14 @@ export class ZulipClient {
     emoji_code?: string;
     reaction_type?: string;
   }): Promise<void> {
-    await this.client.post(`/messages/${messageId}/reactions`, {
+    const payload: any = {
       emoji_name: params.emoji_name,
-      emoji_code: params.emoji_code,
       reaction_type: params.reaction_type || 'unicode_emoji'
-    });
+    };
+    if (params.emoji_code !== undefined) {
+      payload.emoji_code = params.emoji_code;
+    }
+    await this.client.post(`/messages/${messageId}/reactions`, payload);
   }
 
   async removeReaction(messageId: number, params: {
@@ -266,7 +274,11 @@ export class ZulipClient {
     topic?: string;
     scheduled_delivery_timestamp?: number;
   }): Promise<void> {
-    await this.client.patch(`/scheduled_messages/${scheduledMessageId}`, params);
+    // Filter out undefined values
+    const filteredParams = Object.fromEntries(
+      Object.entries(params).filter(([_, value]) => value !== undefined)
+    );
+    await this.client.patch(`/scheduled_messages/${scheduledMessageId}`, filteredParams);
   }
 
   async getScheduledMessages(): Promise<{ scheduled_messages: ZulipScheduledMessage[] }> {
@@ -337,7 +349,11 @@ export class ZulipClient {
     client_gravatar?: boolean;
     include_custom_profile_fields?: boolean;
   } = {}): Promise<{ members: ZulipUser[] }> {
-    const response = await this.client.get('/users', { params });
+    // Filter out undefined values
+    const filteredParams = Object.fromEntries(
+      Object.entries(params).filter(([_, value]) => value !== undefined)
+    );
+    const response = await this.client.get('/users', { params: filteredParams });
     return response.data;
   }
 
@@ -345,7 +361,11 @@ export class ZulipClient {
     client_gravatar?: boolean;
     include_custom_profile_fields?: boolean;
   } = {}): Promise<{ user: ZulipUser }> {
-    const response = await this.client.get(`/users/${encodeURIComponent(email)}`, { params });
+    // Filter out undefined values
+    const filteredParams = Object.fromEntries(
+      Object.entries(params).filter(([_, value]) => value !== undefined)
+    );
+    const response = await this.client.get(`/users/${encodeURIComponent(email)}`, { params: filteredParams });
     return response.data;
   }
 
@@ -354,8 +374,19 @@ export class ZulipClient {
     away?: boolean;
     emoji_name?: string;
     emoji_code?: string;
+    reaction_type?: string;
   }): Promise<void> {
-    await this.client.post('/users/me/status', params);
+    // Filter out undefined values
+    const filteredParams: any = {};
+    if (params.status_text !== undefined) filteredParams.status_text = params.status_text;
+    if (params.away !== undefined) filteredParams.away = params.away;
+    if (params.emoji_name !== undefined) filteredParams.emoji_name = params.emoji_name;
+    if (params.emoji_code !== undefined) filteredParams.emoji_code = params.emoji_code;
+    if (params.reaction_type !== undefined) filteredParams.reaction_type = params.reaction_type;
+    
+    console.error('🔍 Debug - updateStatus filtered params:', JSON.stringify(filteredParams, null, 2));
+    
+    await this.client.post('/users/me/status', filteredParams);
   }
 
   async getUserGroups(): Promise<{ user_groups: ZulipUserGroup[] }> {


### PR DESCRIPTION
## Summary
• Enhanced update-status tool with full Zulip API compliance including `reaction_type` parameter
• Fixed undefined value issues across all client methods and server tools
• Added comprehensive parameter validation and better error messages

## Key Changes
- **update-status tool**: Added missing `reaction_type` parameter with detailed descriptions for unicode_emoji, realm_emoji, and zulip_extra_emoji types
- **Client methods**: Added undefined filtering to prevent "Client did not pass any new values" API errors across updateMessage, addReaction, editScheduledMessage, getMessages, getUsers, getUserByEmail
- **Server tools**: Enhanced parameter validation for edit-message, send-message, edit-scheduled-message
- **Type safety**: Maintained required vs optional parameter contracts with better error handling

## Impact
- Resolves "Client did not pass any new values" errors from Zulip API
- Full feature parity with Zulip update-status API endpoint  
- More robust parameter handling across all 19 MCP tools
- Better user experience with clearer error messages

## Test Plan
- [x] TypeScript compilation passes
- [x] All undefined values properly filtered before API calls
- [x] Parameter validation works correctly
- [ ] Manual testing of update-status tool functionality
- [ ] Manual testing of other affected tools

thearlabs and claude code